### PR TITLE
🔀 :: [#90] 설정 페이지 로깅

### DIFF
--- a/Projects/Feature/SettingsFeature/Sources/EventLog/AllergySettingButtonClickedEventLog.swift
+++ b/Projects/Feature/SettingsFeature/Sources/EventLog/AllergySettingButtonClickedEventLog.swift
@@ -1,0 +1,10 @@
+import TWLog
+
+struct AllergySettingButtonClickedEventLog: EventLog {
+    let name: String = "allergy_setting_button_clicked_on_setting_page"
+    let params: [String: Any]
+
+    init() {
+        self.params = EventLogParameterBuilder().build()
+    }
+}

--- a/Projects/Feature/SettingsFeature/Sources/EventLog/InquireButtonClickedEventLog.swift
+++ b/Projects/Feature/SettingsFeature/Sources/EventLog/InquireButtonClickedEventLog.swift
@@ -1,0 +1,10 @@
+import TWLog
+
+struct InquireButtonClickedEventLog: EventLog {
+    let name: String = "inquire_button_clicked_on_setting_page"
+    let params: [String: Any]
+
+    init() {
+        self.params = EventLogParameterBuilder().build()
+    }
+}

--- a/Projects/Feature/SettingsFeature/Sources/EventLog/InquireTypeSelectedEventLog.swift
+++ b/Projects/Feature/SettingsFeature/Sources/EventLog/InquireTypeSelectedEventLog.swift
@@ -1,0 +1,17 @@
+import TWLog
+
+enum SelectedInquireType: String {
+    case mail
+    case github
+}
+
+struct InquireTypeSelectedEventLog: EventLog {
+    let name: String = "inquire_type_selected_on_inquire_modal"
+    let params: [String: Any]
+
+    init(inquireType: SelectedInquireType) {
+        self.params = EventLogParameterBuilder()
+            .set(key: "type", value: inquireType.rawValue)
+            .build()
+    }
+}

--- a/Projects/Feature/SettingsFeature/Sources/EventLog/IsOnModifiedTimeTableToggledEventLog.swift
+++ b/Projects/Feature/SettingsFeature/Sources/EventLog/IsOnModifiedTimeTableToggledEventLog.swift
@@ -1,0 +1,12 @@
+import TWLog
+
+struct IsOnModifiedTimeTableToggledEventLog: EventLog {
+    let name: String = "is_on_modified_time_table_toggled_on_setting_page"
+    let params: [String: Any]
+
+    init(isOnModifiedTimeTable: Bool) {
+        self.params = EventLogParameterBuilder()
+            .set(key: "value", value: isOnModifiedTimeTable)
+            .build()
+    }
+}

--- a/Projects/Feature/SettingsFeature/Sources/EventLog/IsSkipAfterDinnerToggledEventLog.swift
+++ b/Projects/Feature/SettingsFeature/Sources/EventLog/IsSkipAfterDinnerToggledEventLog.swift
@@ -1,0 +1,12 @@
+import TWLog
+
+struct IsSkipAfterDinnerToggledEventLog: EventLog {
+    let name: String = "is_skip_after_dinner_toggled_on_setting_page"
+    let params: [String: Any]
+
+    init(isSkipAfterDinner: Bool) {
+        self.params = EventLogParameterBuilder()
+            .set(key: "value", value: isSkipAfterDinner)
+            .build()
+    }
+}

--- a/Projects/Feature/SettingsFeature/Sources/EventLog/IsSkipWeekendToggledEventLog.swift
+++ b/Projects/Feature/SettingsFeature/Sources/EventLog/IsSkipWeekendToggledEventLog.swift
@@ -1,0 +1,12 @@
+import TWLog
+
+struct IsSkipWeekendToggledEventLog: EventLog {
+    let name: String = "is_skip_weekend_toggled_on_setting_page"
+    let params: [String: Any]
+
+    init(isSkipWeekend: Bool) {
+        self.params = EventLogParameterBuilder()
+            .set(key: "value", value: isSkipWeekend)
+            .build()
+    }
+}

--- a/Projects/Feature/SettingsFeature/Sources/EventLog/ModifyTimeTableButtonClickedEventLog.swift
+++ b/Projects/Feature/SettingsFeature/Sources/EventLog/ModifyTimeTableButtonClickedEventLog.swift
@@ -1,0 +1,10 @@
+import TWLog
+
+struct ModifyTimeTableButtonClickedEventLog: EventLog {
+    let name: String = "modify_time_table_button_clicked_on_setting_page"
+    let params: [String: Any]
+
+    init() {
+        self.params = EventLogParameterBuilder().build()
+    }
+}

--- a/Projects/Feature/SettingsFeature/Sources/EventLog/SchoolSettingButtonClickedEventLog.swift
+++ b/Projects/Feature/SettingsFeature/Sources/EventLog/SchoolSettingButtonClickedEventLog.swift
@@ -1,0 +1,10 @@
+import TWLog
+
+struct SchoolSettingButtonClickedEventLog: EventLog {
+    let name: String = "school_setting_button_clicked_on_setting_page"
+    let params: [String: Any]
+
+    init() {
+        self.params = EventLogParameterBuilder().build()
+    }
+}

--- a/Projects/Feature/SettingsFeature/Sources/SettingsCore.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsCore.swift
@@ -77,19 +77,34 @@ public struct SettingsCore: Reducer {
                 state.isSkipWeekend = isSkipWeekend
                 userDefaultsClient.setValue(.isSkipWeekend, isSkipWeekend)
 
+                let log = IsSkipWeekendToggledEventLog(isSkipWeekend: isSkipWeekend)
+                TWLog.event(log)
+
             case let .isSkipAfterDinnerChanged(isSkipAfterDinner):
                 state.isSkipAfterDinner = isSkipAfterDinner
                 userDefaultsClient.setValue(.isSkipAfterDinner, isSkipAfterDinner)
+
+                let log = IsSkipAfterDinnerToggledEventLog(isSkipAfterDinner: isSkipAfterDinner)
+                TWLog.event(log)
 
             case let .isOnModifiedTimeTableChagned(isOnModifiedTimeTable):
                 state.isOnModifiedTimeTable = isOnModifiedTimeTable
                 userDefaultsClient.setValue(.isOnModifiedTimeTable, isOnModifiedTimeTable)
 
+                let log = IsOnModifiedTimeTableToggledEventLog(isOnModifiedTimeTable: isOnModifiedTimeTable)
+                TWLog.event(log)
+
             case .schoolBlockButtonDidTap:
                 state.schoolSettingCore = .init()
 
+                let log = SchoolSettingButtonClickedEventLog()
+                TWLog.event(log)
+
             case .modifyTimeTableButtonDidTap:
                 state.modifyTimeTableCore = .init()
+
+                let log = ModifyTimeTableButtonClickedEventLog()
+                TWLog.event(log)
 
             case .modifyTimeTableCore(.dismiss):
                 state.modifyTimeTableCore = nil
@@ -99,6 +114,9 @@ public struct SettingsCore: Reducer {
 
             case .allergyBlockButtonDidTap:
                 state.allergySettingCore = .init()
+                
+                let log = AllergySettingButtonClickedEventLog()
+                TWLog.event(log)
 
             case .allergySettingCore(.dismiss):
                 state.allergySettingCore = nil
@@ -122,15 +140,24 @@ public struct SettingsCore: Reducer {
                     }
                 }
 
+                let log = InquireButtonClickedEventLog()
+                TWLog.event(log)
+
             case .alert(.presented(.githubIssueButtonDidTap)),
                  .confirmationDialog(.presented(.githubIssueButtonDidTap)):
                 guard let url = URL(string: "https://github.com/baekteun/TodayWhat-new/issues") else { break }
                 UIApplication.shared.open(url)
 
+                let log = InquireTypeSelectedEventLog(inquireType: .github)
+                TWLog.event(log)
+
             case .alert(.presented(.mailIssueButtonDidTap)),
                  .confirmationDialog(.presented(.mailIssueButtonDidTap)):
                 guard let url = URL(string: "mailto:baegteun@gmail.com") else { break }
                 UIApplication.shared.open(url)
+
+                let log = InquireTypeSelectedEventLog(inquireType: .mail)
+                TWLog.event(log)
 
             case .alert(.dismiss):
                 state.alert = nil


### PR DESCRIPTION
## 💡 개요
- 설정 페이지의 각 요소에 로그를 심어요

## 📃 작업내용
- 학교 설정 버튼 클릭
- 알레르기 설정 버튼 클릭
- 문의하기 버튼 클릭
  - 메일로 문의하기 버튼 클릭
  - 깃허브로 문의하기 버튼 클릭
- 시간표 수정 버튼 클릭
- 저녁 후 내일 급식 표시 토클
- 커스텀 시간표 표시 토클
- 주말 건너뛰기 토글

를 로깅해요