### PR TITLE
🔀 :: [#130] 설정 화면의 time table cell의 cornerRadius 실수 수정

### DIFF
--- a/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
+++ b/Projects/Feature/SettingsFeature/Sources/SettingsView.swift
@@ -91,7 +91,7 @@ public struct SettingsView: View {
 
     @ViewBuilder
     func timeTableSettingsView() -> some View {
-        blockView {
+        blockView(corners: []) {
             viewStore.send(.modifyTimeTableButtonDidTap)
         } label: {
             settingsOptionChevronView(icon: .writingPencil, text: "시간표 수정")


### PR DESCRIPTION
## 💡 개요
설정 화면 시간표 수정 버튼의 radius 정상화
#130 

## 📃 작업내용

## 🔀 변경사항
<div>
  <img src="https://github.com/baekteun/TodayWhat-new/assets/74440939/cf642f8d-4e58-442e-a298-9e9f2e603d48" width="150" />
  <img src="https://github.com/baekteun/TodayWhat-new/assets/74440939/e1f5a24e-7937-457d-b6ed-2c2919744abe" width="150" />
</div>

